### PR TITLE
- Create needed manifest to build rpm package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,6 @@
+include requirements.txt
+include etc/mdserver
+include etc/default/mdserver
+include etc/mdserver/mdserver.conf
+include etc/init/sysv/mdserver
+include etc/init/systemd/system/mdserver.service


### PR DESCRIPTION
I was trying to run a python setup.py bdist_rpm and it looked like the requirements.txt file wasn't being pulled into the tar properly, read a few things online and they said to create a manifest file to fix it.. so I did.. and it did.