### PR TITLE
Allow the user to supply extra data to templates.

### DIFF
--- a/etc/mdserver/mdserver.conf
+++ b/etc/mdserver/mdserver.conf
@@ -37,3 +37,16 @@ default = not a real key
 # <ip> <basename>
 # default: base
 # entry_order=prefix,domain,base
+
+# The template-data section allows the user to specify a set of key=value pairs
+# that will be made available to the templating engine. The key is used without
+# modification, allowing you to set whatever values you want (as long as there
+# is no conflict with an existing config variable). Values are presented as
+# strings, so any conversion that is required must be done via python code
+# within the template.
+#
+# In the example below, {{foo}} will be available to the template, with value
+# "bar".
+#
+# [template-data]
+# foo=bar

--- a/etc/mdserver/mdserver.conf.test
+++ b/etc/mdserver/mdserver.conf.test
@@ -5,3 +5,6 @@ hostname-prefix = vm-test
 
 [public-keys]
 default = not a real key
+
+[template-data]
+foo=bar


### PR DESCRIPTION
This change adds a new section to the config file called
'template-data', which contains key=value pairs that will be made
available to the template engine (and hence to the userdata templates).
The data is made available using the unmodified key, so that (for
example):

```
[template-data]
foo=bar
```

would make `{{foo}}` available for use in the template, with value `bar`.

Values are always passed as strings, with no conversion of any kind - if
any type conversion is required it needs to be done in python code in
the template.