### PR TITLE
Service info

### DIFF
--- a/etc/mdserver/mdserver.conf.test
+++ b/etc/mdserver/mdserver.conf.test
@@ -1,7 +1,11 @@
 [mdserver]
+listen_address=127.0.0.1
 port=8001
 password = password-test
 hostname-prefix = vm-test
+loglevel=debug
+debug=yes
+logfile=/tmp/mdserver.log
 
 [public-keys]
 default = not a real key

--- a/mdserver/server.py
+++ b/mdserver/server.py
@@ -278,9 +278,10 @@ class MetadataHandler(object):
 
     def gen_versions(self):
         client_host = bottle.request.get('REMOTE_ADDR')
+        config = bottle.request.app.config
         logger.debug("Getting versions for %s", client_host)
 
-        return self.make_content(["2009-04-04/"])
+        return self.make_content([config['mdserver.md_base']])
 
     def gen_base(self):
         client_host = bottle.request.get('REMOTE_ADDR')
@@ -351,7 +352,7 @@ class MetadataHandler(object):
 
         config = bottle.request.app.config
         config = self._get_public_keys(config)
-        config = self._get_template_data(self, config)
+        config = self._get_template_data(config)
         if config['mdserver.password']:
             config['mdserver_password'] = config['mdserver.password']
         config['hostname'] = self.gen_hostname().strip('\n')
@@ -421,6 +422,33 @@ class MetadataHandler(object):
         iid = "i-%s" % client_host
         return self.make_content(iid)
 
+    def gen_service_info(self):
+        client_host = bottle.request.get('REMOTE_ADDR')
+        logger.debug("Getting service info for %s", client_host)
+        return self.make_content([
+            'name',
+            'type',
+            'version',
+        ])
+
+    def gen_service_name(self):
+        client_host = bottle.request.get('REMOTE_ADDR')
+        logger.debug("Getting service name for %s", client_host)
+        config = bottle.request.app.config
+        return self.make_content(config['service.name'])
+
+    def gen_service_type(self):
+        client_host = bottle.request.get('REMOTE_ADDR')
+        logger.debug("Getting service type for %s", client_host)
+        config = bottle.request.app.config
+        return self.make_content(config['service.type'])
+
+    def gen_service_version(self):
+        client_host = bottle.request.get('REMOTE_ADDR')
+        logger.debug("Getting service version for %s", client_host)
+        config = bottle.request.app.config
+        return self.make_content(config['service.version'])
+
     def make_content(self, res):
         if isinstance(res, list):
             return "\n".join(res)
@@ -430,6 +458,9 @@ class MetadataHandler(object):
 
 def main():
     app = bottle.default_app()
+    app.config['service.name'] = "mdserver"
+    app.config['service.type'] = "mdserver"
+    app.config['service.version'] = "0.3.0"
     app.config['mdserver.md_base'] = "/2009-04-04"
     app.config['mdserver.password'] = None
     app.config['mdserver.hostname_prefix'] = 'vm'
@@ -503,22 +534,22 @@ def main():
     mdh._set_public_keys(app.config)
 
     route('/', 'GET', mdh.gen_versions)
-    route(app.config['mdserver.md_base'], 'GET', mdh.gen_base)
-    route(app.config['mdserver.md_base'] + '/meta-data/',
-          'GET', mdh.gen_metadata)
-    route(app.config['mdserver.md_base'] + '/user-data',
-          'GET', mdh.gen_userdata)
-    route(app.config['mdserver.md_base'] + '/meta-data/hostname',
-          'GET', mdh.gen_hostname)
-    route(app.config['mdserver.md_base'] + '/meta-data/instance-id',
-          'GET', mdh.gen_instance_id)
-    route(app.config['mdserver.md_base'] + '/meta-data/public-keys/',
-          'GET', mdh.gen_public_keys)
-    route(app.config['mdserver.md_base'] + '/meta-data/public-keys/<key>/',
-          'GET', mdh.gen_public_key_dir)
-    route((app.config['mdserver.md_base'] +
-           '/meta-data/public-keys/<key>/openssh-key'),
-          'GET', mdh.gen_public_key_file)
+    route('/service/', 'GET', mdh.gen_service_info)
+    route('/service/name', 'GET', mdh.gen_service_name)
+    route('/service/type', 'GET', mdh.gen_service_type)
+    route('/service/version', 'GET', mdh.gen_service_version)
+
+    md_base = app.config['mdserver.md_base']
+    route(md_base + '/', 'GET', mdh.gen_base)
+    route(md_base + '/meta-data/', 'GET', mdh.gen_metadata)
+    route(md_base + '/user-data', 'GET', mdh.gen_userdata)
+    route(md_base + '/meta-data/hostname', 'GET', mdh.gen_hostname)
+    route(md_base + '/meta-data/instance-id', 'GET', mdh.gen_instance_id)
+    route(md_base + '/meta-data/public-keys/', 'GET', mdh.gen_public_keys)
+    route(md_base + '/meta-data/public-keys/<key>/', 'GET',
+          mdh.gen_public_key_dir)
+    route((md_base + '/meta-data/public-keys/<key>/openssh-key'), 'GET',
+          mdh.gen_public_key_file)
     svr_port = app.config.get('mdserver.port')
     listen_addr = app.config.get('mdserver.listen_address')
     run(host=listen_addr, port=svr_port)

--- a/mdserver/server.py
+++ b/mdserver/server.py
@@ -540,6 +540,8 @@ def main():
     route('/service/version', 'GET', mdh.gen_service_version)
 
     md_base = app.config['mdserver.md_base']
+    if len(md_base) > 0 and md_base[0] != '/':
+        md_base = '/' + md_base
     route(md_base + '/', 'GET', mdh.gen_base)
     route(md_base + '/meta-data/', 'GET', mdh.gen_metadata)
     route(md_base + '/user-data', 'GET', mdh.gen_userdata)


### PR DESCRIPTION
Provide information about the metadata service, to allow clients (i.e. cloud-init) to make informed choices about the data we're providing.